### PR TITLE
当在非主线程进行订阅时，抛出异常

### DIFF
--- a/convert/src/main/java/android/arch/convert/RxJavaConvert.kt
+++ b/convert/src/main/java/android/arch/convert/RxJavaConvert.kt
@@ -71,9 +71,8 @@ private class LiveDataObservable<T>(
 ) : Observable<T>() {
 
     override fun subscribeActual(observer: io.reactivex.Observer<in T>) {
-        if (!checkMainThread(observer)) {
-            return
-        }
+        MainThreadDisposable.verifyMainThread()
+
         val relay = RemoveObserverInMainThread(observer)
         observer.onSubscribe(relay)
         liveData.observeForever(relay)
@@ -108,6 +107,8 @@ private class LiveDataCompletable<T>(
         private val allowNull: Boolean = false) : Completable() {
 
     override fun subscribeActual(s: CompletableObserver) {
+        MainThreadDisposable.verifyMainThread()
+
         val relay = CompleteObserver(s)
         s.onSubscribe(relay)
         liveData.observeForever(relay)


### PR DESCRIPTION
我认为在非主线程订阅时直接 return 会导致难以调试、难以察觉问题，抛出异常较为合理。